### PR TITLE
_exists should be based on the id

### DIFF
--- a/src/components/multi-select/multi-select.component.tsx
+++ b/src/components/multi-select/multi-select.component.tsx
@@ -78,7 +78,7 @@ const BTMultiSelect = ({
   };
   const _exists = (item: any) => {
     const existingData = [...selectedValues];
-    return existingData.indexOf(item) > -1 ? true : false;
+    return existingData.map(e => e._id).indexOf(item._id) > -1 ? true : false;
   };
 
   const _filterFunction = (text: string) => {


### PR DESCRIPTION
In JavaScript, objects are assigned and compared by reference, not by value.
This makes pre-loaded impossible to use.